### PR TITLE
Add local Open WebUI knowledge folder and mount into container for RAG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Zusätzlich werden aktuell erste Komponenten für zukünftige KI-/Sprachfunktion
 
 Damit entsteht eine lokale, selbst gehostete Basis für Monitoring, MQTT-Kommunikation, DNS, HTTPS-Zugriffe und perspektivisch auch für KI-gestützte Erweiterungen.
 
+## Open WebUI: RAG mit lokalem Wissensordner
+
+Für die KI-Antworten in **Open WebUI** gibt es jetzt einen lokalen Wissensordner auf Dateiebene:
+
+- Host-Ordner: `open-webui/knowledge/`
+- Container-Pfad: `/app/backend/data/knowledge-import` (read-only gemountet)
+
+So nutzt du ihn:
+
+1. Lege deine Wissensdateien in `open-webui/knowledge/` ab (z. B. `.md`, `.txt`, `.pdf`, `.docx`).
+2. Starte/aktualisiere den Stack mit `docker compose up -d`.
+3. In Open WebUI: **Workspace → Knowledge** öffnen und die Dateien aus diesem Ordner importieren/hochladen.
+4. Beim Chatten dann das entsprechende Knowledge-Objekt auswählen, damit die Antworten auf dieser Wissensbasis laufen (RAG).
+
 **Pi-hole** wird zusätzlich als lokaler DNS-Server und Ad-Blocker vorkonfiguriert. Damit die Namensauflösung im Netzwerk zuverlässig funktioniert, muss **Pi-hole im Router** – z. B. in der **FRITZ!Box** – **korrekt als DNS-Server eingetragen und eingebunden** werden.
 
 **Caddy** wird ebenfalls installiert und vorkonfiguriert, um interne Dienste komfortabel per **HTTPS** bereitzustellen. Dieser Bereich wird aktuell noch weiter ausgebaut.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,6 +247,7 @@ services:
       WEBUI_ADMIN_NAME: ${OPEN_WEBUI_ADMIN_NAME}
     volumes:
       - open-webui:/app/backend/data
+      - ./open-webui/knowledge:/app/backend/data/knowledge-import:ro
 
 
 

--- a/open-webui/knowledge/README.md
+++ b/open-webui/knowledge/README.md
@@ -1,0 +1,11 @@
+# Open WebUI Knowledge Import
+
+Lege hier Dateien ab, die du in Open WebUI als Knowledge-Quellen verwenden willst.
+
+Beispiele:
+- Betriebsanleitungen
+- Notizen/Runbooks
+- Markdown-Dokumentation
+- FAQ-Dateien
+
+Der Ordner wird im Container unter `/app/backend/data/knowledge-import` eingebunden.


### PR DESCRIPTION
### Motivation
- Provide a simple, file-based local knowledge source to enable RAG-style answers in Open WebUI.
- Make it easy to drop documents into the project and expose them into the Open WebUI container for import.

### Description
- Add documentation to `README.md` explaining the new local knowledge folder and how to use it with Open WebUI.
- Mount a read-only host folder into the `open-webui` service by adding `- ./open-webui/knowledge:/app/backend/data/knowledge-import:ro` to `docker-compose.yml`.
- Add `open-webui/knowledge/.gitkeep` and `open-webui/knowledge/README.md` to seed the folder and document intended usage and example file types.
- Apply a minor whitespace/newline cleanup in `README.md`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d23c14efe8832ea3be5cfc64d823df)