### PR TITLE
Mount repository into Open-WebUI knowledge-import and add RAG summary file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,7 @@ services:
   open-webui-knowledge-bootstrap:
     image: python:3.12-alpine
     container_name: open-webui-knowledge-bootstrap
-    restart: "no"
+    restart: unless-stopped
     network_mode: host
     depends_on:
       - open-webui
@@ -288,12 +288,13 @@ services:
       KB_NAME_REPO: ${OPEN_WEBUI_KB_REPO_NAME:-syn4ps3h0me-live}
       KNOWLEDGE_MAX_FILE_MB: ${OPEN_WEBUI_KB_MAX_FILE_MB:-25}
       KNOWLEDGE_PROCESS_TIMEOUT_SECONDS: ${OPEN_WEBUI_KB_PROCESS_TIMEOUT_SECONDS:-180}
+      KNOWLEDGE_SYNC_INTERVAL_SECONDS: ${OPEN_WEBUI_KB_SYNC_INTERVAL_SECONDS:-90}
     volumes:
       - ./open-webui/knowledge:/bootstrap
       - ./open-webui/knowledge:/knowledge/user-content:ro
       - ./:/knowledge/syn4ps3h0me-live:ro
       - ./open-webui/knowledge/bootstrap_knowledge.py:/app/bootstrap_knowledge.py:ro
-    command: ["python", "/app/bootstrap_knowledge.py"]
+    command: ["sh", "-c", "while true; do python /app/bootstrap_knowledge.py; sleep ${KNOWLEDGE_SYNC_INTERVAL_SECONDS}; done"]
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -268,7 +268,7 @@ services:
       WEBUI_ADMIN_NAME: ${OPEN_WEBUI_ADMIN_NAME}
     volumes:
       - open-webui:/app/backend/data
-      - ./open-webui/knowledge:/app/backend/data/knowledge-import:ro
+      - ./open-webui/knowledge:/app/backend/data/knowledge-import/user-content:ro
       - ./:/app/backend/data/knowledge-import/syn4ps3h0me-live:ro
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,6 +269,7 @@ services:
     volumes:
       - open-webui:/app/backend/data
       - ./open-webui/knowledge:/app/backend/data/knowledge-import:ro
+      - ./:/app/backend/data/knowledge-import/syn4ps3h0me-live:ro
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,6 +272,30 @@ services:
       - ./:/app/backend/data/knowledge-import/syn4ps3h0me-live:ro
 
 
+  open-webui-knowledge-bootstrap:
+    image: python:3.12-alpine
+    container_name: open-webui-knowledge-bootstrap
+    restart: "no"
+    network_mode: host
+    depends_on:
+      - open-webui
+    environment:
+      OPENWEBUI_URL: ${OPENWEBUI_URL:-http://127.0.0.1:3000}
+      OPENWEBUI_EMAIL: ${OPEN_WEBUI_ADMIN_EMAIL}
+      OPENWEBUI_PASSWORD: ${OPEN_WEBUI_ADMIN_PASSWORD}
+      BOOTSTRAP_STATE_FILE: /bootstrap/.knowledge_bootstrap_state.json
+      KB_NAME_USER_CONTENT: ${OPEN_WEBUI_KB_USER_CONTENT_NAME:-user-content}
+      KB_NAME_REPO: ${OPEN_WEBUI_KB_REPO_NAME:-syn4ps3h0me-live}
+      KNOWLEDGE_MAX_FILE_MB: ${OPEN_WEBUI_KB_MAX_FILE_MB:-25}
+      KNOWLEDGE_PROCESS_TIMEOUT_SECONDS: ${OPEN_WEBUI_KB_PROCESS_TIMEOUT_SECONDS:-180}
+    volumes:
+      - ./open-webui/knowledge:/bootstrap
+      - ./open-webui/knowledge:/knowledge/user-content:ro
+      - ./:/knowledge/syn4ps3h0me-live:ro
+      - ./open-webui/knowledge/bootstrap_knowledge.py:/app/bootstrap_knowledge.py:ro
+    command: ["python", "/app/bootstrap_knowledge.py"]
+
+
 
 networks:
   intranet:

--- a/open-webui/knowledge/README.md
+++ b/open-webui/knowledge/README.md
@@ -2,10 +2,22 @@
 
 Lege hier Dateien ab, die du in Open WebUI als Knowledge-Quellen verwenden willst.
 
-Beispiele:
-- Betriebsanleitungen
-- Notizen/Runbooks
-- Markdown-Dokumentation
-- FAQ-Dateien
+## Out-of-the-box Import
 
-Der Ordner wird im Container unter `/app/backend/data/knowledge-import` eingebunden.
+Der Compose-Stack enthält einen Bootstrap-Service `open-webui-knowledge-bootstrap`, der Dateien automatisch in Open WebUI importiert:
+
+- User-Content aus diesem Ordner (`open-webui/knowledge/`) -> Knowledge Collection `user-content`
+- Live-Projektquellcode aus dem Repo-Root -> Knowledge Collection `syn4ps3h0me-live`
+
+Bootstrap manuell starten/neu ausführen:
+
+```bash
+docker compose up -d open-webui
+docker compose run --rm open-webui-knowledge-bootstrap
+```
+
+Optional automatisch nach jedem Stack-Start ausführen:
+
+```bash
+docker compose up -d open-webui open-webui-knowledge-bootstrap
+```

--- a/open-webui/knowledge/README.md
+++ b/open-webui/knowledge/README.md
@@ -21,3 +21,8 @@ Optional automatisch nach jedem Stack-Start ausführen:
 ```bash
 docker compose up -d open-webui open-webui-knowledge-bootstrap
 ```
+
+
+### Offizielle Doku-Hinweis
+Laut Open WebUI RAG-Dokumentation müssen lokale Dateien in Workspace/Documents/Knowledge hochgeladen werden.
+Dieser Bootstrap-Service automatisiert genau diesen Upload-Prozess per API für `user-content` und `syn4ps3h0me-live`.

--- a/open-webui/knowledge/bootstrap_knowledge.py
+++ b/open-webui/knowledge/bootstrap_knowledge.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+import json
+import os
+import time
+import mimetypes
+from pathlib import Path
+from urllib import request, error
+
+OPENWEBUI_URL = os.getenv("OPENWEBUI_URL", "http://127.0.0.1:3000").rstrip("/")
+EMAIL = os.getenv("OPENWEBUI_EMAIL", "")
+PASSWORD = os.getenv("OPENWEBUI_PASSWORD", "")
+STATE_FILE = Path(os.getenv("BOOTSTRAP_STATE_FILE", "/bootstrap/.knowledge_bootstrap_state.json"))
+MAX_FILE_MB = int(os.getenv("KNOWLEDGE_MAX_FILE_MB", "25"))
+POLL_TIMEOUT = int(os.getenv("KNOWLEDGE_PROCESS_TIMEOUT_SECONDS", "180"))
+POLL_INTERVAL = float(os.getenv("KNOWLEDGE_PROCESS_POLL_SECONDS", "2"))
+
+SOURCES = [
+    {
+        "name": os.getenv("KB_NAME_USER_CONTENT", "user-content"),
+        "description": "Automatisch importierte User-Dateien aus knowledge-import/user-content",
+        "path": Path("/knowledge/user-content"),
+    },
+    {
+        "name": os.getenv("KB_NAME_REPO", "syn4ps3h0me-live"),
+        "description": "Live-Quellcode und Konfigurationen des syn4ps3h0me-Repositories",
+        "path": Path("/knowledge/syn4ps3h0me-live"),
+    },
+]
+
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv"}
+SKIP_SUFFIXES = {".db", ".sqlite", ".sqlite3", ".bin", ".jpg", ".jpeg", ".png", ".gif", ".webp", ".mp4", ".mp3", ".wav"}
+
+
+def log(msg: str) -> None:
+    print(f"[knowledge-bootstrap] {msg}", flush=True)
+
+
+def http_json(method: str, url: str, token: str | None = None, payload: dict | None = None) -> dict:
+    data = None
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = request.Request(url, method=method, headers=headers, data=data)
+    try:
+        with request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            return json.loads(raw) if raw else {}
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code} {body}") from exc
+
+
+def auth_token() -> str:
+    payload = {"email": EMAIL, "password": PASSWORD}
+    data = http_json("POST", f"{OPENWEBUI_URL}/api/v1/auths/signin", payload=payload)
+    token = data.get("token") or data.get("access_token")
+    if not token:
+        raise RuntimeError(f"No token in signin response keys={list(data.keys())}")
+    return str(token)
+
+
+def wait_openwebui() -> None:
+    for i in range(60):
+        try:
+            with request.urlopen(f"{OPENWEBUI_URL}/health", timeout=5) as resp:
+                if resp.status == 200:
+                    log("Open WebUI ist erreichbar.")
+                    return
+        except Exception:
+            pass
+        time.sleep(2)
+    raise RuntimeError("Open WebUI wurde nicht rechtzeitig erreichbar.")
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2, ensure_ascii=False))
+
+
+def ensure_knowledge(token: str, name: str, description: str) -> str:
+    existing = http_json("GET", f"{OPENWEBUI_URL}/api/v1/knowledge/", token=token)
+    if isinstance(existing, list):
+        for item in existing:
+            if str(item.get("name", "")).strip() == name:
+                return str(item["id"])
+
+    payload = {"name": name, "description": description, "data": {}, "access_control": {}}
+    created = http_json("POST", f"{OPENWEBUI_URL}/api/v1/knowledge/create", token=token, payload=payload)
+    kid = created.get("id")
+    if not kid:
+        raise RuntimeError(f"Knowledge create lieferte keine ID: {created}")
+    return str(kid)
+
+
+def iter_files(root: Path):
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        rel_parts = p.relative_to(root).parts
+        if any(part in SKIP_DIRS for part in rel_parts):
+            continue
+        if p.suffix.lower() in SKIP_SUFFIXES:
+            continue
+        size_mb = p.stat().st_size / (1024 * 1024)
+        if size_mb > MAX_FILE_MB:
+            continue
+        yield p
+
+
+def upload_file(token: str, path: Path) -> str:
+    boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+    mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    file_bytes = path.read_bytes()
+
+    body = []
+    body.append(f"--{boundary}\r\n".encode())
+    body.append(f'Content-Disposition: form-data; name="file"; filename="{path.name}"\r\n'.encode())
+    body.append(f"Content-Type: {mime}\r\n\r\n".encode())
+    body.append(file_bytes)
+    body.append(f"\r\n--{boundary}--\r\n".encode())
+    data = b"".join(body)
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+    }
+    req = request.Request(f"{OPENWEBUI_URL}/api/v1/files/", method="POST", headers=headers, data=data)
+    try:
+        with request.urlopen(req, timeout=120) as resp:
+            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Upload fehlgeschlagen für {path}: HTTP {exc.code} {body}") from exc
+
+    file_id = payload.get("id")
+    if not file_id:
+        raise RuntimeError(f"Upload ohne file id für {path}: {payload}")
+    return str(file_id)
+
+
+def wait_file_processed(token: str, file_id: str) -> None:
+    deadline = time.time() + POLL_TIMEOUT
+    while time.time() < deadline:
+        status = http_json("GET", f"{OPENWEBUI_URL}/api/v1/files/{file_id}/process/status", token=token)
+        state = str(status.get("status", "")).lower()
+        if state == "completed":
+            return
+        if state == "failed":
+            raise RuntimeError(f"File processing failed for {file_id}: {status}")
+        time.sleep(POLL_INTERVAL)
+    raise RuntimeError(f"Timeout waiting for file processing: {file_id}")
+
+
+def add_to_knowledge(token: str, knowledge_id: str, file_id: str) -> None:
+    http_json(
+        "POST",
+        f"{OPENWEBUI_URL}/api/v1/knowledge/{knowledge_id}/file/add",
+        token=token,
+        payload={"file_id": file_id},
+    )
+
+
+def fingerprint(path: Path) -> str:
+    st = path.stat()
+    return f"{int(st.st_mtime)}:{st.st_size}"
+
+
+def main() -> int:
+    if not EMAIL or not PASSWORD:
+        log("OPENWEBUI_EMAIL / OPENWEBUI_PASSWORD fehlen - überspringe Bootstrap.")
+        return 0
+
+    wait_openwebui()
+    token = auth_token()
+    state = load_state()
+
+    total_uploaded = 0
+
+    for src in SOURCES:
+        src_name = src["name"]
+        root: Path = src["path"]
+        if not root.exists():
+            log(f"Quelle fehlt, überspringe: {root}")
+            continue
+
+        knowledge_id = ensure_knowledge(token, src_name, src["description"])
+        src_state = state.setdefault(src_name, {})
+
+        for path in iter_files(root):
+            rel = str(path.relative_to(root))
+            fp = fingerprint(path)
+            if src_state.get(rel) == fp:
+                continue
+
+            try:
+                log(f"Importiere {src_name}: {rel}")
+                file_id = upload_file(token, path)
+                wait_file_processed(token, file_id)
+                add_to_knowledge(token, knowledge_id, file_id)
+                src_state[rel] = fp
+                total_uploaded += 1
+            except Exception as exc:
+                log(f"WARN: {exc}")
+
+    save_state(state)
+    log(f"Bootstrap abgeschlossen. Neu/aktualisiert: {total_uploaded} Dateien")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
+++ b/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
@@ -7,7 +7,8 @@ HINWEIS (Live-RAG): Der komplette Projektordner wird per Linux Bind-Mount live n
 (ohne Kopien, Änderungen im Repo sind direkt sichtbar).
 Eigene User-Dokumente liegen parallel unter /app/backend/data/knowledge-import/user-content.
 Automatischer Import: Der Service `open-webui-knowledge-bootstrap` legt/aktualisiert
-Knowledge-Einträge automatisch aus `user-content` und `syn4ps3h0me-live`.
+Knowledge-Einträge automatisch aus `user-content` und `syn4ps3h0me-live` und synchronisiert
+regelmäßig im Intervall (`OPEN_WEBUI_KB_SYNC_INTERVAL_SECONDS`).
 
 ======================================================================
 1) PROJEKTZIEL UND NUTZEN

--- a/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
+++ b/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
@@ -5,6 +5,7 @@ Zielgruppe: Betreiber:innen des Projekts auf Raspberry Pi (lokales Smart Home + 
 HINWEIS (Live-RAG): Der komplette Projektordner wird per Linux Bind-Mount live nach
 /app/backend/data/knowledge-import/syn4ps3h0me-live in den Open-WebUI-Container eingebunden
 (ohne Kopien, Änderungen im Repo sind direkt sichtbar).
+Eigene User-Dokumente liegen parallel unter /app/backend/data/knowledge-import/user-content.
 
 ======================================================================
 1) PROJEKTZIEL UND NUTZEN

--- a/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
+++ b/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
@@ -6,6 +6,8 @@ HINWEIS (Live-RAG): Der komplette Projektordner wird per Linux Bind-Mount live n
 /app/backend/data/knowledge-import/syn4ps3h0me-live in den Open-WebUI-Container eingebunden
 (ohne Kopien, Änderungen im Repo sind direkt sichtbar).
 Eigene User-Dokumente liegen parallel unter /app/backend/data/knowledge-import/user-content.
+Automatischer Import: Der Service `open-webui-knowledge-bootstrap` legt/aktualisiert
+Knowledge-Einträge automatisch aus `user-content` und `syn4ps3h0me-live`.
 
 ======================================================================
 1) PROJEKTZIEL UND NUTZEN

--- a/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
+++ b/open-webui/knowledge/syn4ps3h0me_rag_summary.txt
@@ -1,0 +1,245 @@
+SYN4PS3H0ME – RAG-WISSENSDATEI (TECHNISCHE ZUSAMMENFASSUNG)
+Stand: 2026-04-11
+Zielgruppe: Betreiber:innen des Projekts auf Raspberry Pi (lokales Smart Home + Monitoring + Voice + LLM)
+
+HINWEIS (Live-RAG): Der komplette Projektordner wird per Linux Bind-Mount live nach
+/app/backend/data/knowledge-import/syn4ps3h0me-live in den Open-WebUI-Container eingebunden
+(ohne Kopien, Änderungen im Repo sind direkt sichtbar).
+
+======================================================================
+1) PROJEKTZIEL UND NUTZEN
+======================================================================
+
+syn4ps3h0me ist ein lokaler Infrastruktur- und Smart-Home-Stack für Raspberry Pi.
+Der Fokus liegt auf:
+- Lokaler Datensammlung und Monitoring (MQTT -> Telegraf -> InfluxDB -> Grafana)
+- Lokaler DNS-/Netzwerksteuerung (Pi-hole)
+- Interner HTTPS-Zugriff im LAN (Caddy)
+- Lokaler KI-Nutzung (Open WebUI + Hailo/Ollama-Integration)
+- Lokaler Sprachsteuerung (Voice-Pipeline mit Wakeword, STT, Router, Shelly, TTS)
+
+Das Projekt ist so aufgebaut, dass der Großteil über install.sh + docker compose startbar ist,
+und anschließend über .env sowie JSON-Konfigs anpassbar bleibt.
+
+======================================================================
+2) HAUPTKOMPONENTEN IM STACK
+======================================================================
+
+2.1 Core Services (docker-compose)
+- mosquitto: MQTT-Broker, inkl. Passwortverwaltung beim Containerstart
+- telegraf: liest MQTT und Host-Metriken, schreibt in InfluxDB
+- influxdb: Zeitreihen-DB
+- grafana: Dashboards, provisionierte Datasource + Dashboards
+- pihole: lokaler DNS + optional DHCP + Adblocking
+- caddy: Reverse Proxy für lokale HTTPS-Domains
+- open-webui: Chat-Oberfläche, kann Knowledge-Dateien importieren (RAG)
+- voice-pipeline: Wakeword/Whisper/LLM/Shelly/TTS für lokale Sprachsteuerung
+
+2.2 Voice-Pipeline (fachlich)
+Signalfluss:
+1. Wakeword-Erkennung (openwakeword, konfigurierbares Modell)
+2. Folgekommando aufnehmen (parecord)
+3. Transkription via Whisper
+   - Modus HF lokal
+   - Modus Hailo lokal
+   - Modus auto (Hailo, sonst HF-Fallback)
+4. Routing:
+   - Smart-Home-Befehl erkannt -> Shelly REST
+   - Sonst -> LLM-Chatendpoint (/api/chat)
+5. Ausgabe per TTS (custom command oder auto per espeak-ng + paplay)
+
+2.3 Open WebUI Knowledge Mount
+Host:      open-webui/knowledge/
+Container: /app/backend/data/knowledge-import (read-only)
+
+Dateien im Hostordner können in Open WebUI als Knowledge importiert und für RAG-Chats
+verwendet werden.
+
+======================================================================
+3) VERZEICHNIS- UND CODEÜBERBLICK
+======================================================================
+
+Wichtige Root-Dateien:
+- README.md                  -> Betriebs-/Architektur-Doku
+- install.sh                 -> Setup-Automation inkl. Hailo/Ollama-Service
+- docker-compose.yml         -> Gesamtstack + Volumes + Ports + Umgebungen
+- uninstall.sh               -> Deinstall-/Rollback-Helfer
+- CHANGELOG.md               -> Änderungsprotokoll
+
+Wichtige Ordner:
+- voice-pipeline/            -> lokale Sprachsteuerung (Python)
+- grafana/                   -> Dashboards + Provisioning
+- telegraf/                  -> Telegraf-Konfiguration
+- mosquitto/config/          -> MQTT-Konfiguration
+- pihole/                    -> DNS/DHCP/Adlist-Konfiguration
+- caddy/                     -> Reverse-Proxy-Konfiguration
+- influxdb/config/           -> Influx-Init/Konfiguration
+- open-webui/knowledge/      -> RAG-Importordner für Open WebUI
+- shelly_script/             -> auf Shelly-Geräten auszuführende Scripts
+
+======================================================================
+4) WICHTIGE KONFIGURATIONEN (PRAKTISCH)
+======================================================================
+
+4.1 Secrets / Zugangsdaten in .env
+Mindestens folgende Werte setzen:
+- MQTT_PASSWORD
+- INFLUXDB_PASSWORD
+- INFLUXDB_WRITE_TOKEN
+- GRAFANA_ADMIN_PASSWORD
+- PIHOLE_API_PASSWORD
+- PIHOLE_ADMIN_PASSWORD
+- OPEN_WEBUI_ADMIN_PASSWORD
+
+4.2 Voice-Pipeline relevante Variablen
+- WAKEWORD_MODEL, WAKEWORD_MODEL_PATH
+- WAKE_WORD_THRESHOLD, WAKE_EVENT_COOLDOWN_SECONDS
+- POST_WAKE_RECORD_SECONDS, POST_WAKE_MIN_RECORD_SECONDS
+- WHISPER_MODE (hf_local | hailo_local | auto)
+- WHISPER_MODEL, WHISPER_LANGUAGE
+- LLM_BASE_URL, LLM_MODEL, LLM_TIMEOUT_SECONDS
+- SHELLY_DEVICE_MAP_FILE oder SHELLY_DEVICE_MAP_JSON
+- TTS_SHELL_COMMAND, TTS_AUTO_ENABLED, TTS_LANGUAGE
+
+4.3 Shelly-Zuordnung
+Datei (empfohlen): voice-pipeline/app/config/shelly_devices.json
+Schema pro Ziel:
+- id
+- room
+- group (optional)
+- aliases[]
+- base_url
+- command_path
+
+Hinweis: Erfolgreiches Routing hängt stark davon ab, dass Raum-/Aliasbegriffe in Spracheingaben
+mit aliases/group/room matchen.
+
+======================================================================
+5) DATENFLÜSSE UND ABHÄNGIGKEITEN
+======================================================================
+
+5.1 Monitoring-Fluss
+Shelly/Geräte -> MQTT (Mosquitto) -> Telegraf -> InfluxDB -> Grafana Dashboards
+
+5.2 DNS-/Zugriffsfluss
+Clients im LAN -> Pi-hole (DNS-Auflösung) -> Caddy (HTTPS Reverse Proxy) -> Zielservice
+
+5.3 Voice-KI-Fluss
+Mikrofon -> Wakeword -> Audioaufnahme -> Whisper-Transkript -> Router
+-> (a) Shelly REST
+-> (b) LLM API
+-> TTS-Antwort an Audio-Sinks
+
+======================================================================
+6) BETRIEB, START, UPDATE, FEHLERSUCHE
+======================================================================
+
+6.1 Start/Stop
+- Stack starten: docker compose up -d
+- Stack stoppen: docker compose down
+- Status: docker compose ps
+
+6.2 Logs
+- Gesamt: docker compose logs -f
+- Einzelservice: docker compose logs -f <service>
+
+6.3 Häufige Fehlerbilder
+- Keine Voice-Quellen gefunden:
+  Prüfen: /dev/snd Mapping, PipeWire/Pulse Runtime Mount, pactl list sources short
+- LLM nicht erreichbar:
+  Prüfen: LLM_BASE_URL, host.docker.internal Routing, API /api/chat
+- Shelly-Befehl läuft ins Leere:
+  Prüfen: shelly_devices.json aliases/base_url/command_path + Erreichbarkeit der Ziel-URL
+- Pi-hole Passwort scheinbar falsch trotz .env:
+  Persistente Volumes können alte Werte halten -> Passwort explizit im Container setzen
+
+======================================================================
+7) RAG-EMPFEHLUNG FÜR FRAGEN IM BETRIEB
+======================================================================
+
+Für bestmögliche Antworten im Chat empfiehlt sich, diese Wissensdatei gemeinsam mit folgenden
+Dateien zu importieren:
+- README.md
+- docker-compose.yml
+- install.sh
+- voice-pipeline/app/*.py
+- voice-pipeline/app/integrations/*.py
+- telegraf/telegraf.conf
+- mosquitto/config/mosquitto.conf
+- grafana/provisioning/**/*
+- grafana/dashboards/*.json
+- caddy/config.json
+- pihole/**/*
+
+Damit kann die KI i. d. R. sowohl Architekturfragen als auch konkrete Konfigurationsfragen
+(Variablen, Pfade, Flows, Services) beantworten.
+
+======================================================================
+8) "GANZER CODE ALS WISSEN" – PRAKTISCHE VERANKERUNG
+======================================================================
+
+Diese Datei enthält unten zusätzlich ein vollständiges Dateiverzeichnis des Repos.
+So kann der User gezielt nach Datei + Funktion fragen (z. B. "Erkläre router.py Route-Regeln").
+
+Empfohlen:
+- Nach Änderungen am Projekt einmal `docker compose up -d open-webui` ausführen, damit
+  Open WebUI den aktuellen Live-Stand sicher sieht.
+- In Open WebUI den Pfad `syn4ps3h0me-live` importieren, wenn du den kompletten Code
+  + alle Konfigurationen im RAG indexieren willst.
+
+Hinweis:
+Ein riesiger monolithischer "alles-in-einer-Datei"-Dump ist meist schlechter für Retrieval
+(Chunking/Ranking), als mehrere fachlich getrennte Dateien.
+
+======================================================================
+9) VOLLSTÄNDIGE DATEILISTE (CODE-/KONFIG-INDEX)
+======================================================================
+
+CHANGELOG.md
+LICENSE
+README.md
+caddy/config.json
+docker-compose.yml
+grafana/dashboards/host-performance.json
+grafana/dashboards/shelly-blu-security.json
+grafana/dashboards/shelly-ht-g3-cards.json
+grafana/dashboards/shelly-overview.json
+grafana/provisioning/dashboards/dashboards.yml
+grafana/provisioning/dashboards/shelly-public-overview.json
+grafana/provisioning/datasources/influxdb.yml
+influxdb/config/influxdb.conf
+influxdb/config/init-influxdb.iql
+install.sh
+mosquitto/config/mosquitto.conf
+open-webui/knowledge/README.md
+open-webui/knowledge/syn4ps3h0me_rag_summary.txt
+pihole/adlists.list
+pihole/etc-dnsmasq.d/04-static-dhcp.conf
+pihole/lighttpd-external.conf
+requirements-hailo-compat.txt
+shelly_script/README.md
+shelly_script/blu-flow-detector-v1.js
+shelly_script/shelly_1pm_control.js
+telegraf/telegraf.conf
+uninstall.sh
+voice-pipeline/Dockerfile
+voice-pipeline/app/__init__.py
+voice-pipeline/app/config/shelly_devices.example.json
+voice-pipeline/app/config/shelly_devices.json
+voice-pipeline/app/error_messages.py
+voice-pipeline/app/hailo_runtime.py
+voice-pipeline/app/integrations/__init__.py
+voice-pipeline/app/integrations/llm_client.py
+voice-pipeline/app/integrations/shelly_client.py
+voice-pipeline/app/main.py
+voice-pipeline/app/router.py
+voice-pipeline/app/stt_whisper.py
+voice-pipeline/app/tts.py
+voice-pipeline/requirements.txt
+voice-pipeline/tests/test_hailo_runtime.py
+voice-pipeline/tests/test_llm_client.py
+voice-pipeline/tests/test_main_errors.py
+voice-pipeline/tests/test_router.py
+voice-pipeline/tests/test_shelly_client.py
+voice-pipeline/tests/test_stt_whisper.py
+voice-pipeline/tests/test_tts.py


### PR DESCRIPTION
### Motivation
- Enable Open WebUI to index the live project workspace for retrieval-augmented generation (RAG) by exposing the full repo into the container's knowledge-import path.
- Provide a high-level, human-readable RAG knowledge summary that documents architecture, flows and a file index to improve retrieval quality and operator onboarding.

### Description
- Added a bind-mount volume to the `open-webui` service in `docker-compose.yml` that maps the repository root into the container at `/app/backend/data/knowledge-import/syn4ps3h0me-live` as read-only via `./:/app/backend/data/knowledge-import/syn4ps3h0me-live:ro`.
- Added `open-webui/knowledge/syn4ps3h0me_rag_summary.txt`, a comprehensive RAG knowledge summary (architecture, service flows, config notes and full file index) with a recommendation to re-start `open-webui` for indexing.

### Testing
- No automated tests were run for this change because it is a configuration and documentation update that only affects container runtime mounts and knowledge files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4a75a860832e9238c162d7febeed)