### PR TITLE
Add backup & restore automation (backup.sh, restore.sh, cron installer) and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,3 +690,16 @@ Details zu Änderungen und Ports stehen in `CHANGELOG.md`.
 Damit die Kosten im Dashboard korrekt dargestellt werden, 
 müsst ihr in der Datei `shelly-overview.json` im Bereich 
 **Gesamtkosten** den Standardwert `0.3577` durch euren eigenen Strompreis ersetzen.
+
+## Backup & Restore (automatisiert)
+
+- `./backup.sh`: erstellt ein vollständiges Backup (Influx logical + Volumes).
+- `./install-backup-cron.sh`: richtet einen täglichen Cronjob um **03:00 Uhr** ein.
+- `./restore.sh <backup-ordner|latest>`: stellt ein Backup manuell wieder her (mit Sicherheitsabfrage).
+
+Beispiel:
+```bash
+./install-backup-cron.sh
+./backup.sh
+./restore.sh latest
+```

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# syn4ps3h0me backup script
+# - Creates InfluxDB logical backups (best for restore/migration)
+# - Creates Docker volume archives for InfluxDB + Mosquitto (full safety net)
+# - Rotates old backups
+
+BACKUP_ROOT="${BACKUP_ROOT:-$PWD/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+TIMESTAMP="$(date +%F_%H-%M-%S)"
+TARGET_DIR="$BACKUP_ROOT/$TIMESTAMP"
+LATEST_LINK="$BACKUP_ROOT/latest"
+
+# Compose/container names used by this repository
+INFLUX_CONTAINER="${INFLUX_CONTAINER:-influx-db}"
+
+# Volumes from docker-compose.yml
+VOLUMES=(
+  influxdb_data
+  influxdb_config
+  mosquitto_data
+  mosquitto_log
+)
+
+log() {
+  printf '[%s] %s\n' "$(date '+%F %T')" "$*"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd docker
+require_cmd tar
+require_cmd find
+mkdir -p "$TARGET_DIR"
+
+log "Starting backup into $TARGET_DIR"
+
+# 1) Influx logical backup
+log "Running InfluxDB logical backup"
+docker exec "$INFLUX_CONTAINER" sh -lc 'rm -rf /tmp/influx-backup && influx backup /tmp/influx-backup'
+docker cp "$INFLUX_CONTAINER":/tmp/influx-backup "$TARGET_DIR/influx-logical"
+
+# 2) Volume tar backups
+log "Archiving Docker volumes"
+for vol in "${VOLUMES[@]}"; do
+  out="$TARGET_DIR/${vol}.tar.gz"
+  log " - $vol -> $(basename "$out")"
+  docker run --rm \
+    -v "$vol":/from:ro \
+    -v "$TARGET_DIR":/to \
+    alpine sh -c "tar czf /to/${vol}.tar.gz -C /from ."
+done
+
+# 3) Metadata for easier restore/troubleshooting
+cat > "$TARGET_DIR/backup-meta.txt" <<META
+created_at=$(date -Is)
+hostname=$(hostname)
+influx_container=$INFLUX_CONTAINER
+volumes=${VOLUMES[*]}
+META
+
+# 4) latest symlink and retention
+ln -sfn "$TARGET_DIR" "$LATEST_LINK"
+
+log "Applying retention: removing backup directories older than $RETENTION_DAYS days"
+find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d -mtime +"$RETENTION_DAYS" -print -exec rm -rf {} +
+
+log "Backup completed successfully"
+log "Backup location: $TARGET_DIR"

--- a/install-backup-cron.sh
+++ b/install-backup-cron.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs a daily cronjob at 03:00 to run backup.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_SCRIPT="$SCRIPT_DIR/backup.sh"
+LOG_DIR="$SCRIPT_DIR/backups"
+LOG_FILE="$LOG_DIR/backup-cron.log"
+
+mkdir -p "$LOG_DIR"
+
+if ! command -v crontab >/dev/null 2>&1; then
+  echo "ERROR: crontab command not found." >&2
+  exit 1
+fi
+
+LINE="0 3 * * * cd $SCRIPT_DIR && BACKUP_ROOT=$SCRIPT_DIR/backups ./backup.sh >> $LOG_FILE 2>&1"
+
+( crontab -l 2>/dev/null | grep -v 'backup.sh'; echo "$LINE" ) | crontab -
+
+echo "Cronjob installed:"
+echo "$LINE"

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# syn4ps3h0me restore script
+# Manual-only execution with safety prompt.
+# Restores:
+# - InfluxDB logical backup (if present)
+# - Docker volumes (influxdb_data, influxdb_config, mosquitto_data, mosquitto_log)
+
+if [[ "${AUTO_RESTORE:-}" == "1" ]]; then
+  echo "ERROR: AUTO_RESTORE is not allowed. Run this script manually." >&2
+  exit 1
+fi
+
+if [[ -t 0 ]]; then
+  :
+else
+  echo "ERROR: restore.sh requires an interactive terminal (manual execution only)." >&2
+  exit 1
+fi
+
+BACKUP_ROOT="${BACKUP_ROOT:-$PWD/backups}"
+INFLUX_CONTAINER="${INFLUX_CONTAINER:-influx-db}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
+
+usage() {
+  cat <<USAGE
+Usage:
+  ./restore.sh <backup-folder>
+  ./restore.sh latest
+
+Examples:
+  ./restore.sh backups/2026-05-25_03-00-00
+  ./restore.sh latest
+
+Environment overrides:
+  BACKUP_ROOT (default: ./backups)
+  INFLUX_CONTAINER (default: influx-db)
+  COMPOSE_FILE (default: docker-compose.yml)
+USAGE
+}
+
+log() {
+  printf '[%s] %s\n' "$(date '+%F %T')" "$*"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd docker
+require_cmd tar
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+arg="$1"
+if [[ "$arg" == "latest" ]]; then
+  BACKUP_DIR="$BACKUP_ROOT/latest"
+else
+  BACKUP_DIR="$arg"
+fi
+
+if [[ ! -d "$BACKUP_DIR" ]]; then
+  echo "ERROR: backup directory not found: $BACKUP_DIR" >&2
+  exit 1
+fi
+
+log "Selected backup: $BACKUP_DIR"
+read -r -p "This will overwrite live data. Type RESTORE to continue: " confirm
+if [[ "$confirm" != "RESTORE" ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+# Stop services to avoid write activity during volume restore
+log "Stopping stack"
+docker compose -f "$COMPOSE_FILE" down
+
+restore_volume() {
+  local volume="$1"
+  local tarfile="$BACKUP_DIR/${volume}.tar.gz"
+
+  if [[ ! -f "$tarfile" ]]; then
+    log "WARN: $tarfile not found, skipping volume $volume"
+    return
+  fi
+
+  log "Restoring volume $volume from $(basename "$tarfile")"
+  docker run --rm -v "$volume":/to alpine sh -c 'rm -rf /to/* /to/.[!.]* /to/..?* || true'
+  docker run --rm -v "$volume":/to -v "$BACKUP_DIR":/from alpine sh -c "cd /to && tar xzf /from/${volume}.tar.gz"
+}
+
+restore_volume influxdb_data
+restore_volume influxdb_config
+restore_volume mosquitto_data
+restore_volume mosquitto_log
+
+log "Starting only InfluxDB for logical restore phase"
+docker compose -f "$COMPOSE_FILE" up -d influxdb
+sleep 5
+
+if [[ -d "$BACKUP_DIR/influx-logical" ]]; then
+  log "Running InfluxDB logical restore"
+  docker cp "$BACKUP_DIR/influx-logical" "$INFLUX_CONTAINER":/tmp/restore
+  docker exec "$INFLUX_CONTAINER" sh -lc 'influx restore /tmp/restore/influx-backup || influx restore /tmp/restore'
+else
+  log "No influx-logical folder found, skipping logical restore"
+fi
+
+log "Starting full stack"
+docker compose -f "$COMPOSE_FILE" up -d
+
+log "Restore completed"


### PR DESCRIPTION
### Motivation

- Provide an automated, reproducible backup and restore workflow for InfluxDB and related Docker volumes with retention and easy restoration. 
- Allow scheduled daily backups via a simple cron installer and document usage in the repository README.

### Description

- Add `backup.sh` which creates InfluxDB logical backups, archives specified Docker volumes (`influxdb_data`, `influxdb_config`, `mosquitto_data`, `mosquitto_log`), writes metadata, rotates old backups, and updates a `latest` symlink. 
- Add `restore.sh` which enforces interactive confirmation, stops the compose stack, restores volume tarballs, performs the InfluxDB logical restore if present, and brings the stack back up. 
- Add `install-backup-cron.sh` which installs a daily `03:00` cronjob to run `backup.sh` and log output. 
- Update `README.md` to document the Backup & Restore automation with usage examples and references to the new scripts. 

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145489f234832e99ee1f1625dbfb14)