### PR TITLE
Grafana: Langzeit-Panel Zeitbereich auf 10 Jahre setzen

### DIFF
--- a/grafana/dashboards/shelly-ht-g3-cards.json
+++ b/grafana/dashboards/shelly-ht-g3-cards.json
@@ -737,7 +737,9 @@
         }
       ],
       "title": "🌍 Langzeit: Jahresmittel & Trend (alle H&T)",
-      "type": "timeseries"
+      "type": "timeseries",
+      "timeFrom": "now-10y",
+      "hideTimeOverride": false
     }
   ],
   "preload": false,


### PR DESCRIPTION
### Motivation
- Das Langzeit-Panel aggregiert Jahresmittel über mehrere Jahre, wurde aber durch das Dashboard-Standardzeitfenster (`now-7d`) abgeschnitten, wodurch praktisch nur der letzte Datenpunkt angezeigt wurde.

### Description
- In `grafana/dashboards/shelly-ht-g3-cards.json` wurde für das Panel "🌍 Langzeit: Jahresmittel & Trend (alle H&T)" die Panel-Optionen `"timeFrom": "now-10y"` und `"hideTimeOverride": false` ergänzt, damit der Verlauf über 10 Jahre sichtbar ist.

### Testing
- JSON-Syntax wurde mit `python -m json.tool grafana/dashboards/shelly-ht-g3-cards.json` geprüft und war gültig; the command succeeded.
- Die Änderung wurde per `git` hinzugefügt und mit einer Commit-Nachricht erfolgreich erstellt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b42ef610832e94f902c915c49f16)