### PR TITLE
Show daily temperature history in H&T Grafana panel

### DIFF
--- a/grafana/dashboards/shelly-ht-g3-cards.json
+++ b/grafana/dashboards/shelly-ht-g3-cards.json
@@ -728,15 +728,15 @@
       "pluginVersion": "12.4.1",
       "targets": [
         {
-          "query": "import \"strings\"\nfrom(bucket: \"shelly\")\n  |> range(start: 2018-01-01T00:00:00Z, stop: now())\n  |> filter(fn: (r) => r._measurement == \"shelly_ht\" and r._field == \"temperature_c\")\n  |> map(fn: (r) => ({\n    r with\n    shelly_name: if exists r.device then string(v: r.device) else if exists r.topic then strings.trimPrefix(v: strings.split(v: r.topic, t: \"/\")[0], prefix: \"shelly_ht_\") else \"unbekannt\"\n  }))\n  |> group(columns: [\"shelly_name\"])\n  |> aggregateWindow(every: 1y, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({ r with series: r.shelly_name + \" Jahresmittel\" }))\n  |> group(columns: [\"series\"])\n  |> keep(columns: [\"_time\", \"_value\", \"series\"])",
+          "query": "import \"strings\"\nfrom(bucket: \"shelly\")\n  |> range(start: 2018-01-01T00:00:00Z, stop: now())\n  |> filter(fn: (r) => r._measurement == \"shelly_ht\" and r._field == \"temperature_c\")\n  |> map(fn: (r) => ({\n    r with\n    shelly_name: if exists r.device then string(v: r.device) else if exists r.topic then strings.trimPrefix(v: strings.split(v: r.topic, t: \"/\")[0], prefix: \"shelly_ht_\") else \"unbekannt\"\n  }))\n  |> group(columns: [\"shelly_name\"])\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({ r with series: r.shelly_name + \" Tagesmittel\" }))\n  |> group(columns: [\"series\"])\n  |> keep(columns: [\"_time\", \"_value\", \"series\"])",
           "refId": "A"
         },
         {
-          "query": "import \"strings\"\nfrom(bucket: \"shelly\")\n  |> range(start: 2018-01-01T00:00:00Z, stop: now())\n  |> filter(fn: (r) => r._measurement == \"shelly_ht\" and r._field == \"temperature_c\")\n  |> map(fn: (r) => ({\n    r with\n    shelly_name: if exists r.device then string(v: r.device) else if exists r.topic then strings.trimPrefix(v: strings.split(v: r.topic, t: \"/\")[0], prefix: \"shelly_ht_\") else \"unbekannt\"\n  }))\n  |> group(columns: [\"shelly_name\"])\n  |> aggregateWindow(every: 1y, fn: mean, createEmpty: false)\n  |> movingAverage(n: 3)\n  |> map(fn: (r) => ({ r with series: r.shelly_name + \" 3J-Trend\" }))\n  |> group(columns: [\"series\"])\n  |> keep(columns: [\"_time\", \"_value\", \"series\"])",
+          "query": "import \"strings\"\nfrom(bucket: \"shelly\")\n  |> range(start: 2018-01-01T00:00:00Z, stop: now())\n  |> filter(fn: (r) => r._measurement == \"shelly_ht\" and r._field == \"temperature_c\")\n  |> map(fn: (r) => ({\n    r with\n    shelly_name: if exists r.device then string(v: r.device) else if exists r.topic then strings.trimPrefix(v: strings.split(v: r.topic, t: \"/\")[0], prefix: \"shelly_ht_\") else \"unbekannt\"\n  }))\n  |> group(columns: [\"shelly_name\"])\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\n  |> movingAverage(n: 7)\n  |> map(fn: (r) => ({ r with series: r.shelly_name + \" 7T-Trend\" }))\n  |> group(columns: [\"series\"])\n  |> keep(columns: [\"_time\", \"_value\", \"series\"])",
           "refId": "B"
         }
       ],
-      "title": "🌍 Langzeit: Jahresmittel & Trend (alle H&T)",
+      "title": "🌍 Langzeit: Tagesmittel & Trend (alle H&T)",
       "type": "timeseries",
       "timeFrom": "now-10y",
       "hideTimeOverride": false


### PR DESCRIPTION
### Motivation
- The timeseries panel was aggregating temperature by year, so only one point per year was plotted and the daily Verlauf was not visible; it should show one average per day to display the daily history.

### Description
- Changed `aggregateWindow(every: 1y, fn: mean, ...)` to `aggregateWindow(every: 1d, fn: mean, ...)` in `grafana/dashboards/shelly-ht-g3-cards.json` for the main series.
- Updated the trend smoothing from `movingAverage(n: 3)` to `movingAverage(n: 7)` and renamed series labels from `"Jahresmittel"/"3J-Trend"` to `"Tagesmittel"/"7T-Trend"` to match daily resolution.
- Updated the panel `title` from `"🌍 Langzeit: Jahresmittel & Trend (alle H&T)"` to `"🌍 Langzeit: Tagesmittel & Trend (alle H&T)"`.
- Kept the panel type and time range settings intact and preserved JSON formatting.

### Testing
- Validated JSON syntax with `python -m json.tool grafana/dashboards/shelly-ht-g3-cards.json`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c141aebc832e849e0b3282c5e05f)