### PR TITLE
Always pull images when bringing up Compose services in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -909,14 +909,14 @@ compose_up() {
   fi
 
   if ${SUDO} docker compose version >/dev/null 2>&1; then
-    log "Starte ausgewählte Compose-Services mit docker compose up -d ..."
-    ${SUDO} docker compose up -d --force-recreate "${COMPOSE_SERVICES[@]}"
+    log "Starte ausgewählte Compose-Services mit docker compose up -d --pull always ..."
+    ${SUDO} docker compose up -d --pull always --force-recreate "${COMPOSE_SERVICES[@]}"
     return
   fi
 
   if command -v docker-compose >/dev/null 2>&1; then
-    log "Starte ausgewählte Compose-Services mit docker-compose up -d ..."
-    ${SUDO} docker-compose up -d --force-recreate "${COMPOSE_SERVICES[@]}"
+    log "Starte ausgewählte Compose-Services mit docker-compose up -d --pull always ..."
+    ${SUDO} docker-compose up -d --pull always --force-recreate "${COMPOSE_SERVICES[@]}"
     return
   fi
 
@@ -935,10 +935,10 @@ ensure_open_webui_runtime() {
 
   if ${SUDO} docker compose version >/dev/null 2>&1; then
     log "Recreate open-webui mit Compose ..."
-    ${SUDO} docker compose up -d --force-recreate open-webui || warn "Compose-Recreate für open-webui fehlgeschlagen."
+    ${SUDO} docker compose up -d --pull always --force-recreate open-webui || warn "Compose-Recreate für open-webui fehlgeschlagen."
   elif command -v docker-compose >/dev/null 2>&1; then
     log "Recreate open-webui mit docker-compose ..."
-    ${SUDO} docker-compose up -d --force-recreate open-webui || warn "docker-compose Recreate für open-webui fehlgeschlagen."
+    ${SUDO} docker-compose up -d --pull always --force-recreate open-webui || warn "docker-compose Recreate für open-webui fehlgeschlagen."
   fi
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the latest container images are fetched before recreating services so deployments use up-to-date images when running `docker compose up` or `docker-compose up`.

### Description
- Add `--pull always` to `docker compose up -d` and `docker-compose up -d` invocations inside the `compose_up()` function to force image pulls prior to recreation.
- Add `--pull always` to the `open-webui` recreate commands in `ensure_open_webui_runtime()` while retaining the explicit `docker pull ghcr.io/open-webui/open-webui:main` (with a warn fallback).
- Update the related log messages to indicate the new `--pull always` behavior.
- No other functional changes were made.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1561de8608832e850a4bcac3eca6fd)