### PR TITLE
Add installer-driven DNS_SUFFIX and MQTT_BROKER_FQDN defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,25 @@ Nur so werden die Daten in den vorhandenen Telegraf/Influx/Grafana-Flows korrekt
 
 Die statischen DNS-Einträge liegen in `docker/pihole/custom.list`.
 
+### Vorschlag: Dynamischer DNS-Suffix für FQDN-Defaults
+Damit Konfigurationseinträge standardmäßig FQDNs nutzen (z. B. `mosquitto.zuhause.lan`), kann der Installer beim Setup den DNS-Suffix einmalig abfragen und in `.env` persistieren:
+
+- Neuer `.env`-Key: `DNS_SUFFIX` (Default: `zuhause.lan`)
+- Abgeleiteter `.env`-Key: `MQTT_BROKER_FQDN=mosquitto.${DNS_SUFFIX}`
+- Ziel: Clients (Shelly, Home Assistant, externe Skripte) nutzen FQDN statt IP oder reinem Container-Alias.
+
+Beispielwerte:
+
+```env
+DNS_SUFFIX=zuhause.lan
+MQTT_BROKER_FQDN=mosquitto.zuhause.lan
+```
+
+Praktische Verwendung:
+- Bei Shelly unter MQTT-Server `mosquitto.zuhause.lan` eintragen.
+- In weiteren Clients immer den FQDN aus `MQTT_BROKER_FQDN` verwenden.
+- Auf dem Docker-Host können interne Container weiterhin `mosquitto` verwenden; für externe Geräte im LAN ist FQDN robuster.
+
 ## 3. Setup Schritt-für-Schritt
 
 ### Voraussetzungen

--- a/README.md
+++ b/README.md
@@ -289,21 +289,21 @@ Nur so werden die Daten in den vorhandenen Telegraf/Influx/Grafana-Flows korrekt
 Die statischen DNS-Einträge liegen in `docker/pihole/custom.list`.
 
 ### Vorschlag: Dynamischer DNS-Suffix für FQDN-Defaults
-Damit Konfigurationseinträge standardmäßig FQDNs nutzen (z. B. `mosquitto.zuhause.lan`), kann der Installer beim Setup den DNS-Suffix einmalig abfragen und in `.env` persistieren:
+Damit Konfigurationseinträge standardmäßig FQDNs nutzen (z. B. `mosquitto.home.lan`), kann der Installer beim Setup den DNS-Suffix einmalig abfragen und in `.env` persistieren:
 
-- Neuer `.env`-Key: `DNS_SUFFIX` (Default: `zuhause.lan`)
+- Neuer `.env`-Key: `DNS_SUFFIX` (Default: `home.lan`)
 - Abgeleiteter `.env`-Key: `MQTT_BROKER_FQDN=mosquitto.${DNS_SUFFIX}`
 - Ziel: Clients (Shelly, Home Assistant, externe Skripte) nutzen FQDN statt IP oder reinem Container-Alias.
 
 Beispielwerte:
 
 ```env
-DNS_SUFFIX=zuhause.lan
-MQTT_BROKER_FQDN=mosquitto.zuhause.lan
+DNS_SUFFIX=home.lan
+MQTT_BROKER_FQDN=mosquitto.home.lan
 ```
 
 Praktische Verwendung:
-- Bei Shelly unter MQTT-Server `mosquitto.zuhause.lan` eintragen.
+- Bei Shelly unter MQTT-Server `mosquitto.home.lan` eintragen.
 - In weiteren Clients immer den FQDN aus `MQTT_BROKER_FQDN` verwenden.
 - Auf dem Docker-Host können interne Container weiterhin `mosquitto` verwenden; für externe Geräte im LAN ist FQDN robuster.
 

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,7 @@ ensure_non_secret_env_defaults() {
     "GF_ADMIN_USER=admin"
     "OPEN_WEBUI_ADMIN_EMAIL=admin@local"
     "OPEN_WEBUI_ADMIN_NAME=admin"
+    "DNS_SUFFIX=zuhause.lan"
   )
   local entry key
   for entry in "${defaults[@]}"; do
@@ -504,10 +505,35 @@ use_existing_env_secrets() {
   resolve_missing_env_secrets "${missing[@]}"
 }
 
+
+configure_service_fqdn_defaults() {
+  local dns_suffix=""
+  local mqtt_fqdn=""
+  local answer=""
+
+  dns_suffix="$(read_env_key "DNS_SUFFIX" "${ENV_FILE}")"
+  if [[ -z "${dns_suffix}" ]]; then
+    dns_suffix="zuhause.lan"
+  fi
+
+  read -r -p "DNS-Suffix für Service-FQDNs [${dns_suffix}]: " answer
+  answer="${answer// /}"
+  if [[ -n "${answer}" ]]; then
+    dns_suffix="${answer}"
+  fi
+
+  upsert_env_key "DNS_SUFFIX" "${dns_suffix}" "${ENV_FILE}"
+
+  mqtt_fqdn="mosquitto.${dns_suffix}"
+  upsert_env_key "MQTT_BROKER_FQDN" "${mqtt_fqdn}" "${ENV_FILE}"
+  log "Setze MQTT_BROKER_FQDN auf ${mqtt_fqdn}"
+}
+
 process_password_strategy() {
   ensure_env_file_present
   collect_required_secrets_for_selected_modules
   ensure_non_secret_env_defaults
+  configure_service_fqdn_defaults
   select_password_mode
 
   case "${PASSWORD_MODE}" in

--- a/install.sh
+++ b/install.sh
@@ -180,7 +180,7 @@ ensure_non_secret_env_defaults() {
     "GF_ADMIN_USER=admin"
     "OPEN_WEBUI_ADMIN_EMAIL=admin@local"
     "OPEN_WEBUI_ADMIN_NAME=admin"
-    "DNS_SUFFIX=zuhause.lan"
+    "DNS_SUFFIX=home.lan"
   )
   local entry key
   for entry in "${defaults[@]}"; do
@@ -513,7 +513,7 @@ configure_service_fqdn_defaults() {
 
   dns_suffix="$(read_env_key "DNS_SUFFIX" "${ENV_FILE}")"
   if [[ -z "${dns_suffix}" ]]; then
-    dns_suffix="zuhause.lan"
+    dns_suffix="home.lan"
   fi
 
   read -r -p "DNS-Suffix für Service-FQDNs [${dns_suffix}]: " answer


### PR DESCRIPTION
### Motivation
- Provide a single place to configure a DNS suffix so configuration entries (e.g. MQTT broker) use stable FQDNs instead of fixed IPs or ad-hoc names.
- Make the DNS suffix persistent in `.env` and allow customizing it once during installer runtime so LAN devices can reliably use FQDNs like `mosquitto.zuhause.lan`.

### Description
- Add `DNS_SUFFIX=zuhause.lan` to the `.env` bootstrap defaults in `ensure_non_secret_env_defaults()` in `install.sh`.
- Introduce `configure_service_fqdn_defaults()` in `install.sh` which reads the current `DNS_SUFFIX`, prompts the user to confirm or override it, writes `DNS_SUFFIX` back to `.env`, computes `MQTT_BROKER_FQDN=mosquitto.${DNS_SUFFIX}`, and persists that key as well.
- Invoke `configure_service_fqdn_defaults()` during setup by calling it from `process_password_strategy()` so the step runs early in the installer flow.
- Document the proposal and example usage (including example `.env` values) in `README.md` so users know to use `MQTT_BROKER_FQDN` for external LAN clients.

### Testing
- Performed a shell syntax check with `bash -n install.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15648ce700832eb11e2babe1a13c22)