### PR TITLE
Grafana: Speicherplatz-Verlauf zur Host Performance Overview hinzufügen

### DIFF
--- a/grafana/dashboards/host-performance.json
+++ b/grafana/dashboards/host-performance.json
@@ -567,6 +567,105 @@
               "mode": "off"
             }
           },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.3",
+      "targets": [
+        {
+          "query": "from(bucket:\"shelly\") |> range(start:v.timeRangeStart, stop:v.timeRangeStop) |> filter(fn:(r)=>r._measurement==\"disk\" and r._field==\"used_percent\" and r.path==\"/\") |> aggregateWindow(every:v.windowPeriod, fn:mean, createEmpty:false)",
+          "refId": "A"
+        }
+      ],
+      "title": "Speicherplatz Verlauf (/ belegt)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "influx_shelly"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "decimals": 2,
           "mappings": [],
           "thresholds": {
@@ -589,7 +688,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 20
       },
       "id": 7,
       "options": {
@@ -686,7 +785,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 12
+        "y": 20
       },
       "id": 6,
       "options": {
@@ -756,7 +855,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 28
       },
       "id": 9,
       "options": {
@@ -811,7 +910,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 28
       },
       "id": 8,
       "options": {
@@ -844,7 +943,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 36
       },
       "id": 11,
       "options": {
@@ -905,7 +1004,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 36
       },
       "id": 10,
       "options": {
@@ -938,7 +1037,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 44
       },
       "id": 12,
       "options": {
@@ -977,5 +1076,5 @@
   "timezone": "",
   "title": "Host Performance Overview",
   "uid": "host-perf-overview",
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
### Motivation
- Das Dashboard `Host Performance Overview` soll zusätzlich zum CPU-Temperatur-Verlauf auch den zeitlichen Verlauf der belegten Root-Partition anzeigen.
- Ziel ist eine konsistente Darstellung von Kapazitäts- und Auslastungsmetriken auf derselben Seite zur einfacheren Überwachung.

### Description
- Datei `grafana/dashboards/host-performance.json` erweitert: neues Timeseries-Panel `Speicherplatz Verlauf (/ belegt)` (Panel id 15) hinzugefügt, das `disk.used_percent` für `path=="/"` über den gewählten Dashboard-Zeitraum anzeigt using Influx/Flux-Abfrage.
- Panel-Visualisierung orientiert sich am vorhandenen CPU-Temperatur-Verlauf mit `unit: percent`, `decimals: 1`, Thresholds (0/80) und Legend-Berechnungen `lastNotNull`, `mean`, `max`, sowie `aggregateWindow` über `v.windowPeriod`.
- Nachfolgende Panels in `panels` wurden vertikal nach unten verschoben (y-Positionen erhöht), um Platz für das neue Panel zu schaffen.
- Dashboard-`version` im JSON von `7` auf `8` erhöht.

### Testing
- `python -m json.tool grafana/dashboards/host-performance.json >/dev/null` wurde ausgeführt und prüft valide JSON-Struktur (erfolgreich).
- `git diff --check` wurde ausgeführt, es wurden keine whitespace-/diff-Fehler gefunden (erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37992c6e6c832eaa5769e4ad01f05c)